### PR TITLE
common: a complete stack analysis toolchain

### DIFF
--- a/.github/workflows/scan_stack_usage.yml
+++ b/.github/workflows/scan_stack_usage.yml
@@ -26,6 +26,11 @@ jobs:
         run: |
           sudo apt-get install libdaxctl-dev libndctl-dev
 
+      - name: Install cflow
+        working-directory: ${{ env.CALL_STACKS_TOOLS_PATH }}
+        run: |
+          ./install_cflow.sh
+
       - name: Build PMDK
         env:
           # just to speed up the job
@@ -35,32 +40,10 @@ jobs:
           cd pmdk/src
           make -j$(nproc)
 
-      - name: Install cflow
-        run: |
-          wget https://mirror.easyname.at/gnu/cflow/cflow-latest.tar.gz
-          tar -xzf cflow-latest.tar.gz
-          rm cflow-latest.tar.gz
-          echo cflow-*
-          cd cflow-*
-          ./configure
-          make
-          sudo make install
-
       - name: Make call stacks
         working-directory: ${{ env.CALL_STACKS_TOOLS_PATH }}
         run: |
-          ./make_stack_usage.sh
-          ./make_api.sh
-          ./make_extra.py
-          ./make_cflow.sh
-          # The lower limit comes up from the DAOS memory requirements.
-          # 16kB - 4kB - 720B = 11568B
-          # 16kB = Stack allocated for a single Argobot's ULT
-          #  4kB = a maximum DAOS' stack usage up to calling a PMDK API calls
-          #  720B = safety margin
-          #    ~ = Some OSes, e.g. Ubuntu 22.04, generate call stacks of size
-          # a little bit over the exact limit which is not deemed a problem at the moment.
-          ./make_call_stacks.py --filter-api-file examples/api_filter.txt --filter-lower-limit 11568
+          ./run_call_stacks_analysis.sh
 
       - name: List per-function stack usage for all call stacks of interest
         working-directory: ${{ env.CALL_STACKS_TOOLS_PATH }}

--- a/utils/call_stacks_analysis/README.md
+++ b/utils/call_stacks_analysis/README.md
@@ -10,12 +10,7 @@
 ## Generating call stacks
 
 ```sh
-./make_stack_usage.sh && \
-./make_api.sh && \
-./make_extra.py && \
-./make_cflow.sh && \
-./make_call_stacks.py --filter-api-file examples/api_filter.txt \
-    --filter-lower-limit 11568 --dump-all-stacks
+./run_call_stack_analysis.py
 ```
 
 If succesfull, it produces:

--- a/utils/call_stacks_analysis/examples/api_filter.txt
+++ b/utils/call_stacks_analysis/examples/api_filter.txt
@@ -1,5 +1,3 @@
-# api_filter file containing libpmemobj API calls used in DAOS
-
 pmemobj_alloc
 pmemobj_cancel
 pmemobj_close
@@ -8,6 +6,7 @@ pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_defer_free
 pmemobj_direct
+pmemobj_errormsg
 pmemobj_flush
 pmemobj_free
 pmemobj_memcpy_persist
@@ -16,6 +15,7 @@ pmemobj_reserve
 pmemobj_root
 pmemobj_tx_abort
 pmemobj_tx_add_range
+pmemobj_tx_add_range_direct
 pmemobj_tx_begin
 pmemobj_tx_commit
 pmemobj_tx_end

--- a/utils/call_stacks_analysis/install_cflow.sh
+++ b/utils/call_stacks_analysis/install_cflow.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2025, Hewlett Packard Enterprise Development LP
+#
+#
+# Install the cflow tool
+#
+
+if  which cflow >/dev/null 2>&1; then
+	echo "cflow already installed"
+	exit 0
+fi
+
+wget -q --show-progress "ftp://ftp.gnu.org/gnu/cflow/cflow-latest.tar.gz"
+if [ $? != 0 ]; then
+	echo "Can not download the cflow source code"
+	exit 1
+fi
+
+tar -xzf cflow-latest.tar.gz && ls cflow-* > /dev/null 2>&1
+status=$?
+rm cflow-latest.tar.gz
+if [ $status != 0 ]; then
+	echo "Unexpected contents of the source code package"
+	exit 1
+fi
+
+cd cflow-*
+
+./configure && make && sudo make install
+status=$?
+
+cd - >/dev/null
+rm -rf cflow-*
+
+if [ $status != 0 ]; then
+	echo "Can not install cflow"
+fi
+
+exit $status

--- a/utils/call_stacks_analysis/make_cflow.sh
+++ b/utils/call_stacks_analysis/make_cflow.sh
@@ -12,6 +12,12 @@ UNSAFE=$1 # '-f' to omit security checks
 WD=$(realpath $(dirname "$0"))
 SRC=$(realpath $WD/../../src)
 
+if ! which "cflow" >/dev/null 2>&1; then
+	echo "cflow is not found in the PATH, please check if it is available."
+	echo "If not, please install it using the install_cflow.sh script."
+	exit 1
+fi
+
 API=$WD/api.txt
 if [ ! -f "$API" ]; then
 	echo "$API is missing"

--- a/utils/call_stacks_analysis/run_call_stacks_analysis.sh
+++ b/utils/call_stacks_analysis/run_call_stacks_analysis.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2025, Hewlett Packard Enterprise Development LP
+#
+#
+# Execute complete call stack analysis based on the API subset defined in a file.
+# example/api_filter.txt is used if file is not given.
+# Update the file based on the actual DAOS source code. (Optional)
+#
+
+function usage() {
+        if [ -n "$1" ]; then
+                echo "Error: $1"
+                echo
+        fi
+        echo "usage:"
+        echo "       $0 [OPTIONS]"
+        echo
+        echo "OPTIONS:"
+        echo "  -h, --help         print help"
+        echo "  -d, --daos         use the actual pmemobj API calls from the DAOS source code"
+        echo "  -f, --filter FILE  custom API filter file"
+        echo
+        if [ -n "$1" ]; then
+                exit 1
+        fi
+        exit 0
+}
+
+function main() {
+        local update=$1
+        local filter_name="$2"
+        if [ $update == 1 ]; then
+                wget -q https://github.com/daos-stack/daos/archive/refs/heads/master.zip -O daos.zip
+                unzip -q -o daos.zip
+                rm daos.zip
+                grep -r -E -h -o 'pmemobj_[^(]*\(' 'daos-master/src' | sed 's/(.*$//' | \
+                        sort | uniq > $filter_name
+                rm -rf daos-master
+        fi
+
+        # The lower limit comes up from the DAOS memory requirements.
+        # 16kB - 4kB - 720B = 11568B
+        # 16kB = Stack allocated for a single Argobot's ULT
+        #  4kB = a maximum DAOS' stack usage up to calling a PMDK API calls
+        #  720B = safety margin
+        #    ~ = Some OSes, e.g. Ubuntu 22.04, generate call stacks of size
+        # a little bit over the exact limit which is not deemed a problem at the moment.
+
+        ./make_stack_usage.sh && \
+                ./make_api.sh && \
+                ./make_extra.py && \
+                ./make_cflow.sh && \
+                ./make_call_stacks.py --filter-api-file $filter_name --filter-lower-limit 11568 \
+                        --dump-all-stacks
+        return $?
+}
+
+# Parse options
+update=0
+filter_name="examples/api_filter.txt"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    -d|--daos)
+      update=1
+      ;;
+    -f|--filter)
+      filter_name="$2"
+      shift
+      ;;
+    *)
+      usage "Unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$filter_name" ]; then
+        usage "File parameter is missing"
+fi
+
+main $update "$filter_name"
+
+exit $?


### PR DESCRIPTION
A comprehensive analysis of stack sizes requires several steps. To facilitate this process, these steps have been aggregated into a single script run_call_stacks_analysis.sh. In addition, it is possible to perform this operation based
on the set of functions used in the DAOS project.

The cflow program, a key component of stack analysis, is not available by default on Linux. The install_cflow.sh script solves this problem by downloading the sources,
compiling and then installing the cflow program on the system.

Both scripts has been integrated into their respective GHA workflows to avoid code redundancy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/3)
<!-- Reviewable:end -->
