### PR TITLE
common: expand the sds.at_create CTL to also cover pmemobj_open()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+XXX
+
+	* Version X.X.X
+
+	- expand the sds.at_create CTL to also cover pmemobj_open() (daos-stack/pmdk#5, DAOS-17449)
+	  - Previously, this CTL affected only pmemobj_create().
+	  - Now, it affects both pmemobj_create() and pmemobj_open().
+	  - pmemobj_open() won't be able to open a pool with SDS enabled if the feature is currently
+	  force-disabled.
+	  - Conversely, pmemobj_open() does not issue a warning when attempting to open a pool with SDS disabled
+	  while the feature is force-disabled.
+
 Wed Feb 19 2025 Oksana Sałyk <oksana.salyk@hpe.com>
 
 	* Version 2.1.1

--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -74,9 +74,14 @@ impact of pagefaults. Affects only the **pmemobj_open**() function.
 
 sds.at_create | rw | global | int | int | - | boolean
 
-If set, force-enables or force-disables SDS feature during pool creation.
-Affects only the **pmemobj_create**() function. See **pmempool_feature_query**(3)
-for information about SDS (SHUTDOWN_STATE) feature.
+If set, this option force-enables or force-disables the SDS feature.
+It affects both the **pmemobj_create**() and **pmemobj_open**() functions.
+A pool created while SDS is force-disabled will have the feature persistently disabled.
+To enable the feature for an existing pool, use **pmempool_feature_enable**(3).
+**pmemobj_open**() cannot open a pool with SDS enabled if the feature is currently force-disabled.
+Conversely, pmemobj_open() does not issue a warning when attempting to open a pool with SDS disabled
+while the feature is force-disabled.
+For more information about the SDS (SHUTDOWN_STATE) feature, see **pmempool_feature_query**(3).
 
 copy_on_write.at_open | rw | global | int | int | - | boolean
 

--- a/src/common/ctl_sds.c
+++ b/src/common/ctl_sds.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2018-2021, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * ctl_sds.c -- implementation of the sds CTL namespace
@@ -31,6 +32,10 @@ CTL_WRITE_HANDLER(at_create)(void *ctx, enum ctl_query_source source,
 	SUPPRESS_UNUSED(ctx, source, indexes);
 
 	int arg_in = *(int *)arg;
+
+	if (SDS_at_create != arg_in && arg_in == 0) {
+		CORE_LOG_HARK("PMEM feature disabled: SDS_at_create=0");
+	}
 
 	SDS_at_create = arg_in;
 

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2014-2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * obj.c -- transactional object store implementation
@@ -1046,6 +1047,23 @@ no_valid_env:
 	return OBJ_NLANES;
 }
 
+static inline int
+pool_attr_adjust(struct pool_attr *attr)
+{
+	/* force set SDS feature */
+	if (SDS_at_create) {
+		if (!(attr->features.incompat & POOL_FEAT_SDS)) {
+			ERR_WO_ERRNO(
+				"The SDS feature cannot be force-enabled, as it was disabled at compile time.");
+			return EINVAL;
+		}
+	} else {
+		attr->features.incompat &= ~POOL_FEAT_SDS; /* off */
+	}
+
+	return 0;
+}
+
 /*
  * pmemobj_createU -- create a transactional memory pool (set)
  */
@@ -1059,6 +1077,7 @@ pmemobj_createU(const char *path, const char *layout,
 
 	PMEMobjpool *pop;
 	struct pool_set *set;
+	int ret;
 
 	/* check length of layout */
 	if (layout && (strlen(layout) >= PMEMOBJ_MAX_LAYOUT)) {
@@ -1077,12 +1096,11 @@ pmemobj_createU(const char *path, const char *layout,
 	unsigned runtime_nlanes = obj_get_nlanes();
 
 	struct pool_attr adj_pool_attr = Obj_create_attr;
-
-	/* force set SDS feature */
-	if (SDS_at_create)
-		adj_pool_attr.features.incompat |= POOL_FEAT_SDS;
-	else
-		adj_pool_attr.features.incompat &= ~POOL_FEAT_SDS;
+	ret = pool_attr_adjust(&adj_pool_attr);
+	if (ret != 0) {
+		errno = ret;
+		return NULL;
+	}
 
 	if (util_pool_create(&set, path, poolsize, PMEMOBJ_MIN_POOL,
 			PMEMOBJ_MIN_PART, &adj_pool_attr, &runtime_nlanes,
@@ -1233,7 +1251,14 @@ static int
 obj_pool_open(struct pool_set **set, const char *path, unsigned flags,
 	unsigned *nlanes)
 {
-	if (util_pool_open(set, path, PMEMOBJ_MIN_PART, &Obj_open_attr,
+	struct pool_attr adj_pool_attr = Obj_open_attr;
+	int ret = pool_attr_adjust(&adj_pool_attr);
+	if (ret != 0) {
+		errno = ret;
+		return -1;
+	}
+
+	if (util_pool_open(set, path, PMEMOBJ_MIN_PART, &adj_pool_attr,
 				nlanes, NULL, flags) != 0) {
 		CORE_LOG_ERROR("cannot open pool or pool set");
 		return -1;


### PR DESCRIPTION
https://daosio.atlassian.net/browse/DAOS-17449

Ref: daos-stack/pmdk#5

Unclean cherry-pick of 0bf7f8a565aae101f17aec4bf1c168bda4fa1243

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/14)
<!-- Reviewable:end -->
