### PR TITLE
test: expand the sds.at_create CTL to also cover pmemobj_open() (fix)

### DIFF
--- a/src/test/core_log_max/call_all.c.generated
+++ b/src/test/core_log_max/call_all.c.generated
@@ -259,6 +259,8 @@ call_all_ERR_WO_ERRNO(void)
 	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("%s variable must be a positive integer", _s);
 	// src/libpmemobj/obj.c
+	ERR_WO_ERRNO("The SDS feature cannot be force-enabled, as it was disabled at compile time.");
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("Layout too long");
 	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("initialization of replica #%u failed", _u);

--- a/src/test/core_log_max/core_log_max.c
+++ b/src/test/core_log_max/core_log_max.c
@@ -100,7 +100,7 @@ static int Total_TLS_message_num;
  * A hard-coded value as obtained when the call_all_*() source code was
  * generated.
  */
-#define TOTAL_TLS_MESSAGE_NUM_EXPECTED 310
+#define TOTAL_TLS_MESSAGE_NUM_EXPECTED 311
 
 static int
 test_ERR_W_ERRNO(const struct test_case *tc, int argc, char *argv[])


### PR DESCRIPTION
- add missing log entry

Ref: daos-stack/pmdk#14

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/15)
<!-- Reviewable:end -->
