### PR TITLE
obj: make sure footers are written for all huge memory blocks on chunk reinit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+XXX
+
+	* Version X.X.X
+
+	- Fix an issue in the PMEMOBJ allocator with a potential to corrupt the allocator's metadata (daos-stack/pmdk#24, DAOS-18195).
+
 Tue Nov 4 2025 Oksana Sałyk <oksana.salyk@hpe.com>
 
 	* Version 2.1.2

--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2016-2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * memblock.c -- implementation of memory block
@@ -1185,8 +1186,8 @@ static void
 huge_reinit_chunk(const struct memory_block *m)
 {
 	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
-	if (hdr->type == CHUNK_TYPE_USED)
-		huge_write_footer(hdr, hdr->size_idx);
+	ASSERT(hdr->type == CHUNK_TYPE_USED || hdr->type == CHUNK_TYPE_FREE);
+	huge_write_footer(hdr, hdr->size_idx);
 }
 
 /*


### PR DESCRIPTION
# Requires

- [x] #26

# Issue

Huge memory blocks with the header chunk of type CHUNK_TYPE_FREE had not reinitialized their footer chunk.

# Context

- Allocator divides the available space into zones and zones into smaller chunks.
- All chunk headers belonging to a single zone are stored in an array.
- Chunk header describes its: type, size_idx and flags.
- Chunk can be of a few types. The types important for this patch are: CHUNK_TYPE_FOOTER, CHUNK_TYPE_FREE, and CHUNK_TYPE_USED.
- CHUNK_TYPE_FREE and _USED are chunk types marking the beginning of so called huge memory block. This means this chunk and a number of chunks following it (size_idx) constitues a single allocation or a free memory.
- The last chunk belonging to a huge memory block ought to be of type CHUNK_TYPE_FOOTER. Its size_idx allows to easily find the first chunk belonging to this huge memory block and determine the huge memory block type.
- Huge memory blocks' footers are written immediately but persited lazily. It is not a problem at runtime since the footers are there at runtime. But in case of a crash the footers may be not persisted properly and missing on open. So, when the allocator is booted up it recreates footers just in case any of them is missing.

**Note**: The huge memory block's first chunk header and the last chunk header (footer) are not written nor persisted in any way transactionally. The first chunk header occupies only 8 bytes so it is written and persisted atomically. But its footer is written independently and not explicitly persisted.

**Note**: The first chunk header contains all the required info to recreate footer. The last chunk header is there only to make huge memory blocks coalescing easier to compute. Reading the footer allows to immediately find the memory block leaving just before the memory block which neighbours one might want to find.

This patch makes sure the huge memory block's footer is recreated no matter whather its type is CHUNK_TYPE_FREE or CHUNK_TYPE_USED.

The patch is inspired by work done for DAOS' DAV allocator (DAOS-18195) which is heavily based on the PMEMOBJ allocator.

Inspired-by: Sherin T George <sherin-t.george@hpe.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/24)
<!-- Reviewable:end -->
