### PR TITLE
common: fix "The pool was not closed" message (no ADR failure)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+XXX
+
+	* Version X.X.X
+
+	- Fix "The pool was not closed" message (no ADR failure) (daos-stack/pmdk#1, DAOS-18692)
+
 Fri Jan 16 2026 Oksana Sałyk <oksana.salyk@hpe.com>
 
 	* Version 2.1.3

--- a/src/common/shutdown_state.c
+++ b/src/common/shutdown_state.c
@@ -157,6 +157,8 @@ shutdown_state_clear_dirty(struct shutdown_state *sds, struct pool_replica *rep)
 	shutdown_state_checksum(sds, rep);
 }
 
+#define SDS_REINIT_SUFFIX " - reinitializing the ADR failure detection state."
+
 /*
  * shutdown_state_check -- compares and fixes shutdown state
  */
@@ -194,8 +196,7 @@ shutdown_state_check(struct shutdown_state *curr_sds,
 
 	if (!is_checksum_correct) {
 		/* the program was killed during opening or closing the pool */
-		CORE_LOG_WARNING(
-			"The pool was not opened/closed properly - reinitializing ADR failure detection.");
+		CORE_LOG_WARNING("The pool was not opened/closed properly" SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}
@@ -203,22 +204,18 @@ shutdown_state_check(struct shutdown_state *curr_sds,
 	if (is_uuid_usc_correct) {
 		if (dirty == 0)
 			return 0;
-		/*
-		 * the program was killed when the pool was opened
-		 * but there wasn't an ADR failure
-		 */
-		CORE_LOG_WARNING(
-			"The pool was not closed - reinitializing ADR failure detection.");
+		/* the program was killed when the pool was opened but there wasn't an ADR failure */
+		CORE_LOG_WARNING("The pool was not closed" SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}
 	if (dirty == 0) {
 		if (is_uuid_correct)
 			CORE_LOG_WARNING(
-				"The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.");
+				"The ADR failure was detected but the pool was closed properly" SDS_REINIT_SUFFIX);
 		else
 			CORE_LOG_HARK(
-				"The pool has moved to a new location but it was closed properly - reinitializing ADR failure detection.");
+				"The pool has moved to a new location but it was closed properly" SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}

--- a/src/common/shutdown_state.c
+++ b/src/common/shutdown_state.c
@@ -196,7 +196,9 @@ shutdown_state_check(struct shutdown_state *curr_sds,
 
 	if (!is_checksum_correct) {
 		/* the program was killed during opening or closing the pool */
-		CORE_LOG_WARNING("The pool was not opened/closed properly" SDS_REINIT_SUFFIX);
+		CORE_LOG_WARNING(
+			"The pool was not opened/closed properly"
+			SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}
@@ -204,18 +206,25 @@ shutdown_state_check(struct shutdown_state *curr_sds,
 	if (is_uuid_usc_correct) {
 		if (dirty == 0)
 			return 0;
-		/* the program was killed when the pool was opened but there wasn't an ADR failure */
-		CORE_LOG_WARNING("The pool was not closed" SDS_REINIT_SUFFIX);
+		/*
+		 * the program was killed when the pool was opened but there
+		 * wasn't an ADR failure
+		 */
+		CORE_LOG_WARNING(
+			"The pool was not closed last time, leaving it vulnerable to ADR failures. Luckily, no ADR failure occurred this time"
+			SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}
 	if (dirty == 0) {
 		if (is_uuid_correct)
 			CORE_LOG_WARNING(
-				"The ADR failure was detected but the pool was closed properly" SDS_REINIT_SUFFIX);
+				"The ADR failure was detected but the pool was closed properly"
+				SDS_REINIT_SUFFIX);
 		else
 			CORE_LOG_HARK(
-				"The pool has moved to a new location but it was closed properly" SDS_REINIT_SUFFIX);
+				"The pool has moved to a new location but it was closed properly"
+				SDS_REINIT_SUFFIX);
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}

--- a/src/common/shutdown_state.c
+++ b/src/common/shutdown_state.c
@@ -208,7 +208,7 @@ shutdown_state_check(struct shutdown_state *curr_sds,
 		 * but there wasn't an ADR failure
 		 */
 		CORE_LOG_WARNING(
-			"The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.");
+			"The pool was not closed - reinitializing ADR failure detection.");
 		shutdown_state_reinit(curr_sds, pool_sds, rep);
 		return 0;
 	}

--- a/src/test/core_log_max/call_all.c.generated
+++ b/src/test/core_log_max/call_all.c.generated
@@ -468,7 +468,7 @@ call_all_CORE_LOG_WARNING(void)
 	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("The pool was not opened/closed properly - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
-	CORE_LOG_WARNING("The pool was not closed - reinitializing the ADR failure detection state.");
+	CORE_LOG_WARNING("The pool was not closed last time, leaving it vulnerable to ADR failures. Luckily, no ADR failure occurred this time - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.");
 	// src/libpmemobj/heap.c

--- a/src/test/core_log_max/call_all.c.generated
+++ b/src/test/core_log_max/call_all.c.generated
@@ -468,7 +468,7 @@ call_all_CORE_LOG_WARNING(void)
 	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("The pool was not opened/closed properly - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
-	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.");
+	CORE_LOG_WARNING("The pool was not closed - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.");
 	// src/libpmemobj/heap.c

--- a/src/test/core_log_max/call_all.c.generated
+++ b/src/test/core_log_max/call_all.c.generated
@@ -466,11 +466,11 @@ call_all_CORE_LOG_WARNING(void)
 	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("Enabling ADR failure detection, assuming pool consistency up to this point.");
 	// src/common/shutdown_state.c
-	CORE_LOG_WARNING("The pool was not opened/closed properly - reinitializing ADR failure detection.");
+	CORE_LOG_WARNING("The pool was not opened/closed properly - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
-	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.");
+	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.");
 	// src/common/shutdown_state.c
-	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.");
+	CORE_LOG_WARNING("The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.");
 	// src/libpmemobj/heap.c
 	CORE_LOG_WARNING("failed to allocate memory block runtime tracking info");
 	// src/libpmemobj/heap.c

--- a/src/test/util_sds/grep3.log.match
+++ b/src/test/util_sds/grep3.log.match
@@ -1,1 +1,1 @@
-<libpmem2>: <1> [shutdown_state.c:$(N) shutdown_state_check] The pool has moved to a new location but it was closed properly - reinitializing ADR failure detection.
+<libpmem2>: <1> [shutdown_state.c:$(N) shutdown_state_check] The pool has moved to a new location but it was closed properly - reinitializing the ADR failure detection state.

--- a/src/test/util_sds/grep5.log.match
+++ b/src/test/util_sds/grep5.log.match
@@ -1,1 +1,1 @@
-<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The pool was not closed - reinitializing the ADR failure detection state.
+<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The pool was not closed last time, leaving it vulnerable to ADR failures. Luckily, no ADR failure occurred this time - reinitializing the ADR failure detection state.

--- a/src/test/util_sds/grep5.log.match
+++ b/src/test/util_sds/grep5.log.match
@@ -1,1 +1,1 @@
-<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.
+<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The pool was not closed - reinitializing ADR failure detection.

--- a/src/test/util_sds/grep5.log.match
+++ b/src/test/util_sds/grep5.log.match
@@ -1,1 +1,1 @@
-<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The pool was not closed - reinitializing ADR failure detection.
+<libpmem2>: <2> [shutdown_state.c:$(N) shutdown_state_check] The pool was not closed - reinitializing the ADR failure detection state.

--- a/src/test/util_sds_check/out1.log.match
+++ b/src/test/util_sds_check/out1.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST1: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The pool was not opened/closed properly - reinitializing ADR failure detection.
+The pool was not opened/closed properly - reinitializing the ADR failure detection state.
 util_sds_check$(nW)TEST1: DONE

--- a/src/test/util_sds_check/out2.log.match
+++ b/src/test/util_sds_check/out2.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST2: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The pool was not closed - reinitializing ADR failure detection.
+The pool was not closed - reinitializing the ADR failure detection state.
 util_sds_check$(nW)TEST2: DONE

--- a/src/test/util_sds_check/out2.log.match
+++ b/src/test/util_sds_check/out2.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST2: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.
+The pool was not closed - reinitializing ADR failure detection.
 util_sds_check$(nW)TEST2: DONE

--- a/src/test/util_sds_check/out2.log.match
+++ b/src/test/util_sds_check/out2.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST2: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The pool was not closed - reinitializing the ADR failure detection state.
+The pool was not closed last time, leaving it vulnerable to ADR failures. Luckily, no ADR failure occurred this time - reinitializing the ADR failure detection state.
 util_sds_check$(nW)TEST2: DONE

--- a/src/test/util_sds_check/out3.log.match
+++ b/src/test/util_sds_check/out3.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST3: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The pool has moved to a new location but it was closed properly - reinitializing ADR failure detection.
+The pool has moved to a new location but it was closed properly - reinitializing the ADR failure detection state.
 util_sds_check$(nW)TEST3: DONE

--- a/src/test/util_sds_check/out5.log.match
+++ b/src/test/util_sds_check/out5.log.match
@@ -3,5 +3,5 @@ util_sds_check$(nW)TEST5: START: util_sds_check
 src version: $(nW)
 compiled with support for shutdown state
 compiled with libndctl $(nW)
-The ADR failure was detected but the pool was closed properly - reinitializing ADR failure detection.
+The ADR failure was detected but the pool was closed properly - reinitializing the ADR failure detection state.
 util_sds_check$(nW)TEST5: DONE

--- a/utils/call_stacks_analysis/log_call_all_generate.py
+++ b/utils/call_stacks_analysis/log_call_all_generate.py
@@ -274,7 +274,8 @@ def call_get_format_tokens(call):
 
 LITERAL_TO_STRING = {
     'PRIx64': 'lx',
-    'PRIu64': 'lu'
+    'PRIu64': 'lu',
+    'SDS_REINIT_SUFFIX': ' - reinitializing the ADR failure detection state.',
 }
 
 def token_stringify(token: str) -> str:


### PR DESCRIPTION
Ref: DAOS-18692
Ref: daos-stack/pmdk#1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/36)
<!-- Reviewable:end -->
