### PR TITLE
common: ensure no OFED is installed on self-hosted runner

### DIFF
--- a/utils/ansible/rockylinux-setup.yml
+++ b/utils/ansible/rockylinux-setup.yml
@@ -25,6 +25,12 @@
     new_user_pass: pmdkpass
 
   tasks:
+    - name: Ensure kmod-mlnx-ofa_kernel is not installed
+      ansible.builtin.dnf:
+      name: kmod-mlnx-ofa_kernel
+      state: absent
+      autoremove: true
+
     - name: Update kernel packages
       package:
         name: "kernel.x86_64"


### PR DESCRIPTION
Rocky 9.8 does not have OFED available yet and can not be updated:
`"Failed to validate GPG signature for kmod-mlnx-ofa_kernel-24.10-OFED.24.10.5.1.6.1.rhel9u5.x86_64:
 Public key for kmod-mlnx-ofa_kernel-24.10-OFED.24.10.5.1.6.1.rhel9u5.x86_64.rpm is not installed"`
OFED is not needed for PMDK tests.
Let's ensure OFES is not installed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/39)
<!-- Reviewable:end -->
