### PR TITLE
common: adjust build system to versions like 1.4.99-1-g4cff24b

### DIFF
--- a/utils/docker/test_package/test-packages-installation.py
+++ b/utils/docker/test_package/test-packages-installation.py
@@ -100,7 +100,6 @@ def get_incompatible_packages(packages_path, pkgconfig_directory, split_param):
             if 'version=' in line:
                 version = line.split('=')[1].strip(linesep)
         if not version in PMDK_VERSION:
-            print(f'{version} != {PMDK_VERSION}')
             incompatibe_packages.append(library)
     return incompatibe_packages
 

--- a/utils/docker/test_package/test-packages-installation.py
+++ b/utils/docker/test_package/test-packages-installation.py
@@ -99,7 +99,8 @@ def get_incompatible_packages(packages_path, pkgconfig_directory, split_param):
         for line in out:
             if 'version=' in line:
                 version = line.split('=')[1].strip(linesep)
-        if not version in PMDK_VERSION.replace('~', '-'):
+        if not version in PMDK_VERSION:
+            print(f'{version} != {PMDK_VERSION}')
             incompatibe_packages.append(library)
     return incompatibe_packages
 

--- a/utils/pkg-common.sh
+++ b/utils/pkg-common.sh
@@ -37,7 +37,7 @@ function check_tool() {
 }
 
 function get_version() {
-	echo -n $1 | sed "s/-rc/~rc/"
+	echo -n $1 | sed "s/-/~/g"
 }
 
 function get_os() {

--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -415,6 +415,7 @@ make %{?_smp_mflags} \
 %if %{without ndctl}
 	NDCTL_ENABLE=n \
 %endif
+	SRCVERSION=%{version} \
 	__MAKE_FLAGS__
 
 
@@ -424,6 +425,7 @@ make install DESTDIR=%{buildroot} \
 %if %{without ndctl}
         NDCTL_ENABLE=n \
 %endif
+	SRCVERSION=%{version} \
 	LIB_AR= \
 	prefix=%{_prefix} \
 	libdir=%{_libdir} \


### PR DESCRIPTION
Preview: https://github.com/daos-stack/pmdk/actions/runs/31095435388

**Note**: None of this affects how DAOS builds PMDK.

- RPM version does not accept '-'. Replace them with '~'.
- pmdk.spec has to force SRCVERSION so generated *.pc files specify the same version string.
- fix test so it accepts '~'.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daos-stack/pmdk/45)
<!-- Reviewable:end -->
